### PR TITLE
Added mutex lock to prevent race condition in accessing `m.returnValues` in `Times` condition

### DIFF
--- a/mocker.go
+++ b/mocker.go
@@ -49,19 +49,21 @@ func (m *Mock) generateReplacement(target reflect.Value) reflect.Value {
 			} else {
 				return m.returnValues[0].returnFn.Call(args)
 			}
-		} else if m.returnValues[0].calledTimes < m.returnValues[0].times {
+		} else {
 			// Adding mutex lock to prevent race condition in accessing m.returnValues
 			m.mu.Lock()
 			defer m.mu.Unlock()
 			m.returnValues[0].calledTimes++
-			if reflect.ValueOf(m.returnValues[0].returnFn).IsZero() {
-				rets := m.returnValues[0]
-				if m.returnValues[0].calledTimes >= m.returnValues[0].times {
-					m.returnValues = m.returnValues[1:]
+			if m.returnValues[0].calledTimes < m.returnValues[0].times {
+				if reflect.ValueOf(m.returnValues[0].returnFn).IsZero() {
+					rets := m.returnValues[0]
+					if m.returnValues[0].calledTimes >= m.returnValues[0].times {
+						m.returnValues = m.returnValues[1:]
+					}
+					return rets.returnValues
+				} else {
+					return m.returnValues[0].returnFn.Call(args)
 				}
-				return rets.returnValues
-			} else {
-				return m.returnValues[0].returnFn.Call(args)
 			}
 		}
 		panic("unexpected call to " + m.name)


### PR DESCRIPTION
### Issue
Found a race condition while using this framework where multiple go routines are entering critical section in `generateReplacement` function causing panic with error `out of index`.

#### Example:
- Consider a function `Foo()` and its corresponding test function `TestFoo()`.
- The logic in `Foo` contains spawning of `go routines` and each of them are calling a function `Bar()`.
- In our `TestFoo`, we set the state in such a way that `Bar` will be called exactly 2 times. So, we mock the function `Bar` with `Times(2)` setting `m.returnValues[0].times=2` and `Return` some values which appends a single element in `m.returnValues`.
- Our critical section start from the line (say L1): `m.returnValues[0].calledTimes++` and ends after the `return` from this function.
- In some case, it is possible that both the go routines reached `L1` which makes the value of `m.returnValues[0].calledTimes` equalling `2`. SO, `m.returnValues[0].calledTimes` equals `m.returnValues[0].times`.
- In this case, it is possible only one of the go routine reaches the line `m.returnValues = m.returnValues[1:]` expelling the only element in `m.returnValues`.
- Later, the second go routine reaches the line `rets := m.returnValues[0]`. Here, it is trying to access the first element of an empty slice `m.returnValues` causing panic with error `out of index`.

### Resolution
Using `mutex lock` in such a way that only one go routine can access `m.returnValues` and therefore, only one go routine can increase `m.returnValues[0].calledTimes`.